### PR TITLE
Classpath escaping in assignment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 group 'com.github.alexeylisyutenko'
-version '1.1.0'
+version '1.2.0'
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'

--- a/src/main/resources/installScript.txt
+++ b/src/main/resources/installScript.txt
@@ -13,7 +13,7 @@ if "%APP_HOME%" == "" set APP_HOME=.\\
 set SERVICE_EXE=%APP_HOME%${serviceExeName}
 
 @rem Setup all necessary variables
-set CLASSPATH=${classpath}
+set CLASSPATH="${classpath}"
 
 @rem Install ${applicationName}
 "%SERVICE_EXE%" install ${installOptions}

--- a/src/test/groovy/com/github/alexeylisyutenko/windowsserviceplugin/WindowsServicePluginTest.groovy
+++ b/src/test/groovy/com/github/alexeylisyutenko/windowsserviceplugin/WindowsServicePluginTest.groovy
@@ -13,7 +13,7 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 class WindowsServicePluginTest extends Specification {
 
     @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder()
+    public TemporaryFolder testProjectDir = new TemporaryFolder()
     File buildFile
     File settingsFile
 
@@ -22,7 +22,7 @@ class WindowsServicePluginTest extends Specification {
         settingsFile = testProjectDir.newFile('settings.gradle')
     }
 
-    private Project setupBasicProject() {
+    private static Project setupBasicProject() {
         Project project = ProjectBuilder.builder().build()
         project.apply plugin: 'com.github.alexeylisyutenko.windows-service-plugin'
         return project
@@ -320,7 +320,7 @@ class WindowsServicePluginTest extends Specification {
         then:
         result.task(":createWindowsService").outcome == SUCCESS
         installScriptLines.any {
-            it.contains("set CLASSPATH=%APP_HOME%lib\\testProject.jar;%APP_HOME%lib\\first-dependency.jar;%APP_HOME%lib\\second-dependency.jar;%APP_HOME%lib\\third-dependency.jar")
+            it.contains("set CLASSPATH=\"%APP_HOME%lib\\testProject.jar;%APP_HOME%lib\\first-dependency.jar;%APP_HOME%lib\\second-dependency.jar;%APP_HOME%lib\\third-dependency.jar\"")
         }
         new File(testProjectDir.root, "build/windows-service/lib/testProject.jar").exists()
         new File(testProjectDir.root, "build/windows-service/lib/first-dependency.jar").exists()
@@ -369,7 +369,7 @@ class WindowsServicePluginTest extends Specification {
         then:
         result.task(":createWindowsService").outcome == SUCCESS
         installScriptLines.any {
-            it.contains("set CLASSPATH=%APP_HOME%lib\\first-overriding-classpath-dependency.jar;%APP_HOME%lib\\second-overriding-classpath-dependency.jar")
+            it.contains("set CLASSPATH=\"%APP_HOME%lib\\first-overriding-classpath-dependency.jar;%APP_HOME%lib\\second-overriding-classpath-dependency.jar\"")
         }
         !new File(testProjectDir.root, "build/windows-service/lib/testProject.jar").exists()
         !new File(testProjectDir.root, "build/windows-service/lib/first-dependency.jar").exists()

--- a/src/test/resources/sample-testProject-install.bat
+++ b/src/test/resources/sample-testProject-install.bat
@@ -13,7 +13,7 @@ if "%APP_HOME%" == "" set APP_HOME=.\
 set SERVICE_EXE=%APP_HOME%testProject.exe
 
 @rem Setup all necessary variables
-set CLASSPATH=%APP_HOME%lib\testProject.jar
+set CLASSPATH="%APP_HOME%lib\testProject.jar"
 
 @rem Install testProject
 "%SERVICE_EXE%" install ^


### PR DESCRIPTION
This PR fixes issue #4 which, for example, causes problems for services executed from `C:\Program Files`. (note the space!) The corresponding test is also provided, and the existing tests have also been updated.